### PR TITLE
Fix flaky test com.google.refine.browsing.facets.ListFacetTests.serializeListFacet

### DIFF
--- a/main/src/com/google/refine/browsing/util/ExpressionNominalValueGrouper.java
+++ b/main/src/com/google/refine/browsing/util/ExpressionNominalValueGrouper.java
@@ -78,7 +78,7 @@ public class ExpressionNominalValueGrouper implements RowVisitor, RecordVisitor 
     /*
      * Computed results
      */
-    final public Map<Object, IndexedNominalFacetChoice> choices = new LinkedHashMap<Object, IndexedNominalFacetChoice>();
+    final public Map<Object, IndexedNominalFacetChoice> choices = new HashMap<Object, IndexedNominalFacetChoice>();
     public int blankCount = 0;
     public int errorCount = 0;
 

--- a/main/src/com/google/refine/browsing/util/ExpressionNominalValueGrouper.java
+++ b/main/src/com/google/refine/browsing/util/ExpressionNominalValueGrouper.java
@@ -38,6 +38,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.LinkedHashMap;
 import java.util.Properties;
 
 import com.google.refine.browsing.DecoratedValue;
@@ -77,7 +78,7 @@ public class ExpressionNominalValueGrouper implements RowVisitor, RecordVisitor 
     /*
      * Computed results
      */
-    final public Map<Object, IndexedNominalFacetChoice> choices = new HashMap<Object, IndexedNominalFacetChoice>();
+    final public Map<Object, IndexedNominalFacetChoice> choices = new LinkedHashMap<Object, IndexedNominalFacetChoice>();
     public int blankCount = 0;
     public int errorCount = 0;
 


### PR DESCRIPTION
This PR aims to fix the following 3 flaky test cases:

- [com.google.refine.browsing.facets.ListFacetTests.serializeListFacet](https://github.com/ThugJudy/OpenRefine/blob/d6a00af85a96b389d49e878e6e12765db76ad6b0/main/tests/server/src/com/google/refine/browsing/facets/ListFacetTests.java#L96-L108)
- [com.google.refine.browsing.facets.ListFacetTests.testSelectedEmptyChoice](https://github.com/ThugJudy/OpenRefine/blob/d6a00af85a96b389d49e878e6e12765db76ad6b0/main/tests/server/src/com/google/refine/browsing/facets/ListFacetTests.java#L122-L133)
- [com.google.refine.clustering.binning.BinningClustererTests.testSerializeBinningClusterer](https://github.com/ThugJudy/OpenRefine/blob/d6a00af85a96b389d49e878e6e12765db76ad6b0/main/tests/server/src/com/google/refine/clustering/binning/BinningClustererTests.java#L77-L87)

### Problem
The test case [com.google.refine.browsing.facets.ListFacetTests.serializeListFacet](https://github.com/ThugJudy/OpenRefine/blob/d6a00af85a96b389d49e878e6e12765db76ad6b0/main/tests/server/src/com/google/refine/browsing/facets/ListFacetTests.java#L96-L108) fails due to the below assertion

https://github.com/ThugJudy/OpenRefine/blob/d6a00af85a96b389d49e878e6e12765db76ad6b0/main/tests/server/src/com/google/refine/browsing/facets/ListFacetTests.java#L107

I found and confirmed the flaky behavior using an open-source research tool [NonDex](https://github.com/TestingResearchIllinois/NonDex), which shuffles implementations of nondeterminism operations.

### Fix

The failure occurred because the TestUtil function used to compare two JSONs didn't account for cases where the order of array elements within the JSON is shuffled. To address this, I've implemented a custom function that can handle this scenario.

This change fixes the other 2 test cases as well.

### Reproduce

The following command can be used to reproduce assertion failures and verify the fix:

```
mvn -pl main edu.illinois:nondex-maven-plugin:2.1.1:nondex  -Dtest=com.google.refine.browsing.facets.ListFacetTests
mvn -pl main edu.illinois:nondex-maven-plugin:2.1.1:nondex  -Dtest=com.google.refine.browsing.facets.ListFacetTests#testSelectedEmptyChoice
mvn -pl main edu.illinois:nondex-maven-plugin:2.1.1:nondex  -Dtest=com.google.refine.clustering.binning.BinningClustererTests#testSerializeBinningClusterer
```

Test Environment:
```
Java version "1.8.0_381"
Apache Maven 3.6.3
macOS Venture Version 13.4.1 (22F82)
```
Please let me know if you have any concerns or questions.
